### PR TITLE
INF-56: Cache install depenedencies for Chrometest

### DIFF
--- a/.github/workflows/chrometest_run-batches.yml
+++ b/.github/workflows/chrometest_run-batches.yml
@@ -54,7 +54,6 @@ jobs:
             else ary+="$i]" 
             fi
           done
-          echo $ary
           echo "::set-output name=arr::$ary"
 
   install_dependencies_to_cache:
@@ -134,6 +133,7 @@ jobs:
         run: | 
           ls C:/ProgramData/chocolatey/lib/OpenSans/tools
           ls C:/ProgramData/chocolatey/lib/OpenSans
+          echo ${{ matrix.batch }}
       # - uses: actions/cache@v2
       #   name: Get Fontawesome From Cache
       #   id: cache-fontawesome

--- a/.github/workflows/chrometest_run-batches.yml
+++ b/.github/workflows/chrometest_run-batches.yml
@@ -48,7 +48,7 @@ jobs:
       id: cache-dependencies
       with:
         path: |
-          C:\ProgramData\chocolatey\lib\OpenSans\tools\*.ttf
+          C:\ProgramData\chocolatey\lib\OpenSans\tools
           .\font-awesome-${{ env.FONT_AWESOME_VERSION }}\fonts\fontawesome-webfont.ttf
           C:\Users\runneradmin\Documents\PowerShell\Modules\SimplySql\${{ env.SIMPLY_SQL_VERSION }}
         key: opensans-${{ env.OPENSANS_VERSION }}-fontawesome-${{ env.FONT_AWESOME_VERSION }}-simplysql-${{ env.SIMPLY_SQL_VERSION }}
@@ -93,10 +93,10 @@ jobs:
         id: cache
         with:
           path: |
-            C:\ProgramData\chocolatey\lib\OpenSans\tools\*.ttf
+            C:\ProgramData\chocolatey\lib\OpenSans\tools
             .\font-awesome-${{ env.FONT_AWESOME_VERSION }}\fonts\fontawesome-webfont.ttf
             C:\Users\runneradmin\Documents\PowerShell\Modules\SimplySql\${{ env.SIMPLY_SQL_VERSION }}
-          key: opensans-${{ env.OPENSANS_VERSION }}-fontawesome-${{ env.FONT_AWESOME_VERSION }}-simplysql-${{ env.SIMPLY_SQL_VERSION }}}
+          key: opensans-${{ env.OPENSANS_VERSION }}-fontawesome-${{ env.FONT_AWESOME_VERSION }}-simplysql-${{ env.SIMPLY_SQL_VERSION }}
       - name: Set OpenSans and Fontawesome HKCU
         run: |
           Get-ChildItem -Path C:\ProgramData\chocolatey\lib\OpenSans\tools\*.ttf | %{ Set-ItemProperty -Path "HKCU:\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Fonts" -Name "$($_.Basename) (TrueType)" -Type STRING -Value $_.fullname }
@@ -139,6 +139,7 @@ jobs:
       - name: Report Testruns to Database
         if: always()
         run: |
+          ls C:\Users\runneradmin\Documents\PowerShell\Modules\
           Import-Module -Name SimplySql
           cd ${{ env.TEST_LOCATION }}
           Open-MySqlConnection -ConnectionString "${{ env.CONNECTION_STRING_AUTOTEST_DB }}"

--- a/.github/workflows/chrometest_run-batches.yml
+++ b/.github/workflows/chrometest_run-batches.yml
@@ -91,7 +91,7 @@ jobs:
   run_batch:
     name: Run Chrome Test Batches
     runs-on: windows-2019
-    needs: [install-dependencies-to-cache, generate_batch_matrix]
+    needs: [install_dependencies_to_cache, generate_batch_matrix]
     env:
       BRANCH: ${{ inputs.branch }}
       BUILD_NUMBER: ${{ inputs.buildNumber }}

--- a/.github/workflows/chrometest_run-batches.yml
+++ b/.github/workflows/chrometest_run-batches.yml
@@ -120,7 +120,7 @@ jobs:
           path: C:\ProgramData\chocolatey\lib\OpenSans\tools
           key: -opensans-${{ env.OPENSANS_VERSION }}
       - name: Set OpenSans HKCU
-        run: Get-ChildItem -Path ${{ env.OPENSANS_PATH }}\*.ttf | %{ Set-ItemProperty -Path "HKCU:\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Fonts" -Name "$($_.Basename) (TrueType)" -Type STRING -Value $_.fullname }
+        run: Get-ChildItem -Path C:\ProgramData\chocolatey\lib\OpenSans\tools\*.ttf | %{ Set-ItemProperty -Path "HKCU:\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Fonts" -Name "$($_.Basename) (TrueType)" -Type STRING -Value $_.fullname }
       - uses: actions/cache@v2
         name: Get Fontawesome From Cache
         id: cache-fontawesome

--- a/.github/workflows/chrometest_run-batches.yml
+++ b/.github/workflows/chrometest_run-batches.yml
@@ -63,7 +63,7 @@ jobs:
         path: | 
           C:/ProgramData/chocolatey/lib/OpenSans/tools
           C:/ProgramData/chocolatey/lib/chocolatey-font-helpers.extension/extensions/Install-ChocolateyFont.ps1
-        key: opensans-${{ env.OPENSANS_VERSION }}
+        key: -opensans-${{ env.OPENSANS_VERSION }}
     - name: Install Opensans
       if: steps.cache-opensans.outputs.cache-hit != 'true'
       run: choco install -y opensans --version ${{ env.OPENSANS_VERSION }}
@@ -125,7 +125,7 @@ jobs:
           path: | 
             C:/ProgramData/chocolatey/lib/OpenSans/tools
             C:/ProgramData/chocolatey/lib/chocolatey-font-helpers.extension/extensions/Install-ChocolateyFont.ps1
-          key: opensans-${{ env.OPENSANS_VERSION }}
+          key: -opensans-${{ env.OPENSANS_VERSION }}
       - name: install open sans
         run: |
           Import-Module -Name chcolatey-font-helpers

--- a/.github/workflows/chrometest_run-batches.yml
+++ b/.github/workflows/chrometest_run-batches.yml
@@ -68,8 +68,8 @@ jobs:
       name: Check Opensans Cache
       id: cache-opensans
       with:
-        path: C:/ProgramData/chocolatey/lib/OpenSans/tools
-        key: ${{ runner.os }}-opensans-${{ env.OPENSANS_VERSION }}
+        path: C:/ProgramData/chocolatey/lib/OpenSans
+        key: opensans-${{ env.OPENSANS_VERSION }}
     - name: Install Opensans
       if: steps.cache-opensans.outputs.cache-hit != 'true'
       run: choco install -y opensans --version ${{ env.OPENSANS_VERSION }}
@@ -78,7 +78,7 @@ jobs:
       id: cache-fontawesome
       with:
         path: ./font-awesome-${{ env.FONT_AWESOME_VERSION }}/fonts/fontawesome-webfont.ttf
-        key: ${{ runner.os }}-font-awesome-${{ env.FONT_AWESOME_VERSION }}
+        key: font-awesome-${{ env.FONT_AWESOME_VERSION }}
     - name: Install Fontawesome
       if: steps.cache-fontawesome.outputs.cache-hit != 'true'
       run: |
@@ -92,7 +92,7 @@ jobs:
       id: cache-simplysql
       with:
         path: C:\Users\runneradmin\Documents\PowerShell\Modules\SimplySql\${{ env.SIMPLY_SQL_VERSION }}
-        key: ${{ runner.os }}-simplysql-${{ env.SIMPLY_SQL_VERSION }}
+        key: simplysql-${{ env.SIMPLY_SQL_VERSION }}
     - name: Install SimplySql
       if: steps.cache-simplysql.outputs.cache-hit != 'true'
       run: |
@@ -128,7 +128,7 @@ jobs:
         id: cache-opensans
         with:
           path: C:/ProgramData/chocolatey/lib/OpenSans
-          key: ${{ runner.os }}-opensans-${{ env.OPENSANS_VERSION }}
+          key: opensans-${{ env.OPENSANS_VERSION }}
       - name: Debug Opensans
         run: | 
           ls C:/ProgramData/chocolatey/lib/OpenSans/tools
@@ -139,13 +139,13 @@ jobs:
       #   id: cache-fontawesome
       #   with:
       #     path: ./font-awesome-${{ env.FONT_AWESOME_VERSION }}
-      #     key: ${{ runner.os }}-font-awesome-${{ env.FONT_AWESOME_VERSION }}
+      #     key: font-awesome-${{ env.FONT_AWESOME_VERSION }}
       # - uses: actions/cache@v2
       #   name: Get SimplySql From Cache
       #   id: cache-simplysql
       #   with:
       #     path: C:\Users\runneradmin\Documents\PowerShell\Modules\SimplySql
-      #     key: ${{ runner.os }}-simplysql-${{ env.SIMPLY_SQL_VERSION }}
+      #     key: simplysql-${{ env.SIMPLY_SQL_VERSION }}
       # - name: Fontawesome set HKCU
       #   run: |
       #     $FontPath = Join-Path $pwd font-awesome-${{ env.FONT_AWESOME_VERSION }}\fonts\fontawesome-webfont.ttf

--- a/.github/workflows/chrometest_run-batches.yml
+++ b/.github/workflows/chrometest_run-batches.yml
@@ -60,9 +60,7 @@ jobs:
       name: Check Opensans Cache
       id: cache-opensans
       with:
-        path: | 
-          C:/ProgramData/chocolatey/lib/OpenSans/tools
-          C:/ProgramData/chocolatey/lib/chocolatey-font-helpers.extension/extensions/Install-ChocolateyFont.ps1
+        path: C:\ProgramData\chocolatey\lib\OpenSans\tools
         key: -opensans-${{ env.OPENSANS_VERSION }}
     - name: Install Opensans
       if: steps.cache-opensans.outputs.cache-hit != 'true'
@@ -71,7 +69,7 @@ jobs:
       name: Check Fontawesome Cache
       id: cache-fontawesome
       with:
-        path: ./font-awesome-${{ env.FONT_AWESOME_VERSION }}/fonts/fontawesome-webfont.ttf
+        path: .\font-awesome-${{ env.FONT_AWESOME_VERSION }}\fonts\fontawesome-webfont.ttf
         key: font-awesome-${{ env.FONT_AWESOME_VERSION }}
     - name: Install Fontawesome
       if: steps.cache-fontawesome.outputs.cache-hit != 'true'
@@ -89,10 +87,7 @@ jobs:
         key: simplysql-${{ env.SIMPLY_SQL_VERSION }}
     - name: Install SimplySql
       if: steps.cache-simplysql.outputs.cache-hit != 'true'
-      run: |
-        Install-Module -Name SimplySql -RequiredVersion ${{ env.SIMPLY_SQL_VERSION }} -Confirm:$False -Force
-    - name: check fonts after cache
-      run: Get-ChildItem -Path C:/Windows/Fonts
+      run: Install-Module -Name SimplySql -RequiredVersion ${{ env.SIMPLY_SQL_VERSION }} -Confirm:$False -Force
 
   run_batch:
     name: Run Chrome Test Batches
@@ -122,31 +117,15 @@ jobs:
         name: Get Opensans from cache
         id: cache-opensans
         with:
-          path: | 
-            C:/ProgramData/chocolatey/lib/OpenSans/tools
-            C:/ProgramData/chocolatey/lib/chocolatey-font-helpers.extension/extensions/Install-ChocolateyFont.ps1
+          path: C:\ProgramData\chocolatey\lib\OpenSans\tools
           key: -opensans-${{ env.OPENSANS_VERSION }}
-      - name: install open sans
-        run: |
-          Import-Module -Name chocolatey-font-helpers
-          Install-ChocolateyFont "C:/ProgramData/chocolatey/lib/OpenSans/tools/OpenSans-Bold.ttf"
-          Install-ChocolateyFont "C:/ProgramData/chocolatey/lib/OpenSans/tools/OpenSans-BoldItalic.ttf"
-          Install-ChocolateyFont "C:/ProgramData/chocolatey/lib/OpenSans/tools/OpenSans-CondBold.ttf"
-          Install-ChocolateyFont "C:/ProgramData/chocolatey/lib/OpenSans/tools/OpenSans-CondLight.ttf"
-          Install-ChocolateyFont "C:/ProgramData/chocolatey/lib/OpenSans/tools/OpenSans-CondLightItalic.ttf"
-          Install-ChocolateyFont "C:/ProgramData/chocolatey/lib/OpenSans/tools/OpenSans-ExtraBold.ttf"
-          Install-ChocolateyFont "C:/ProgramData/chocolatey/lib/OpenSans/tools/OpenSans-ExtraBoldItalic.ttf"
-          Install-ChocolateyFont "C:/ProgramData/chocolatey/lib/OpenSans/tools/OpenSans-Italic.ttf"
-          Install-ChocolateyFont "C:/ProgramData/chocolatey/lib/OpenSans/tools/OpenSans-Light.ttf"
-          Install-ChocolateyFont "C:/ProgramData/chocolatey/lib/OpenSans/tools/OpenSans-LightItalic.ttf"
-          Install-ChocolateyFont "C:/ProgramData/chocolatey/lib/OpenSans/tools/OpenSans-Regular.ttf"
-          Install-ChocolateyFont "C:/ProgramData/chocolatey/lib/OpenSans/tools/OpenSans-SemiBold.ttf"
-          Install-ChocolateyFont "C:/ProgramData/chocolatey/lib/OpenSans/tools/OpenSans-SemiBoldItalic.ttf"
+      - name: Set OpenSans HKCU
+        run: Get-ChildItem -Path ${{ env.OPENSANS_PATH }}\*.ttf | %{ Set-ItemProperty -Path "HKCU:\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Fonts" -Name "$($_.Basename) (TrueType)" -Type STRING -Value $_.fullname }
       - uses: actions/cache@v2
         name: Get Fontawesome From Cache
         id: cache-fontawesome
         with:
-          path: ./font-awesome-${{ env.FONT_AWESOME_VERSION }}
+          path: .\font-awesome-${{ env.FONT_AWESOME_VERSION }}\fonts\fontawesome-webfont.ttf
           key: font-awesome-${{ env.FONT_AWESOME_VERSION }}
       - uses: actions/cache@v2
         name: Get SimplySql From Cache
@@ -154,10 +133,10 @@ jobs:
         with:
           path: C:\Users\runneradmin\Documents\PowerShell\Modules\SimplySql\${{ env.SIMPLY_SQL_VERSION }}
           key: simplysql-${{ env.SIMPLY_SQL_VERSION }}
-      - name: Fontawesome set HKCU
+      - name: Set Fontawesome HKCU
         run: |
           $FontPath = Join-Path $pwd font-awesome-${{ env.FONT_AWESOME_VERSION }}\fonts\fontawesome-webfont.ttf
-          Set-ItemProperty -path "HKCU:\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Fonts" -name "FontAwesome" -value "$FontPath"
+          Set-ItemProperty -Path "HKCU:\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Fonts" -Name "FontAwesome" -Value "$FontPath"
       - name: Download and Extract Release
         run: |
           $uri = "${{ env.ENDPOINT_CHROMETEST }}/${{ env.BUILD_NUMBER }}/ChromeTests.7z?${{ secrets.ACCESS_TOKEN_CONTAINER_BUILDS }}"

--- a/.github/workflows/chrometest_run-batches.yml
+++ b/.github/workflows/chrometest_run-batches.yml
@@ -2,8 +2,8 @@ name: Reusable Workflow to Run Chrome Test Batches
 on:
   workflow_call:
     inputs:
-      matrixInput:
-        description: matrix array
+      batchNumber:
+        description: number of batches to run
         required: true
         type: string
       branch:
@@ -35,6 +35,17 @@ on:
         required: true
 
 jobs:
+  generate_batch_matrix:
+    name: Generate Batch Matrix
+    runs-on: ubuntu-latest
+    outputs:
+      MATRIX_ARRAY: ${{ steps.matrixArray.outputs.arr }}
+    env: 
+      ARRAY_SIZE: ${{ inputs.batchNumber }}
+    steps:
+      - id: matrixAraray
+        run: echo "::set-output name=arr::[$(seq -s ", " 0 $[ ${{ env.ARRAY_SIZE }} - 1 ])]"
+
   install_dependencies_to_cache:
     name: Install Dependencies to Caches
     runs-on: windows-2019
@@ -80,7 +91,7 @@ jobs:
   run_batch:
     name: Run Chrome Test Batches
     runs-on: windows-2019
-    needs: [install-dependencies-to-cache]
+    needs: [install-dependencies-to-cache, generate_batch_matrix]
     env:
       BRANCH: ${{ inputs.branch }}
       BUILD_NUMBER: ${{ inputs.buildNumber }}
@@ -99,118 +110,123 @@ jobs:
     strategy:
       fail-fast: false
       matrix: 
-        batch: ${{ inputs.matrixInput }}
+        batch: ${{ fromJSON(needs.generate_batch_matrix.outputs.MATRIX_ARRAY) }}
     steps:
+    
       - uses: actions/cache@v2
         name: Get Opensans from cache
         id: cache-opensans
         with:
           path: C:/ProgramData/chocolatey/lib/OpenSans
           key: ${{ runner.os }}-opensans-${{ env.OPENSANS_VERSION }}
-      - uses: actions/cache@v2
-        name: Get Fontawesome from cache
-        id: cache-fontawesome
-        with:
-          path: ./font-awesome-${{ env.FONT_AWESOME_VERSION }}
-          key: ${{ runner.os }}-font-awesome-${{ env.FONT_AWESOME_VERSION }}
-      - uses: actions/cache@v2
-        name: Get SimplySql from cache
-        id: cache-simplysql
-        with:
-          path: C:\Users\runneradmin\Documents\PowerShell\Modules\SimplySql
-          key: ${{ runner.os }}-simplysql-${{ env.SIMPLY_SQL_VERSION }}
-      - name: Fontawesome set HKCU
-        run: |
-          $FontPath = Join-Path $pwd font-awesome-${{ env.FONT_AWESOME_VERSION }}\fonts\fontawesome-webfont.ttf
-          Set-ItemProperty -path "HKCU:\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Fonts" -name "FontAwesome" -value "$FontPath"
-      - name: Download and Extract Release
-        run: |
-          $uri = "${{ env.ENDPOINT_CHROMETEST }}/${{ env.BUILD_NUMBER }}/ChromeTests.7z?${{ secrets.ACCESS_TOKEN_CONTAINER_BUILDS }}"
-          Invoke-WebRequest -Uri $uri -OutFile ChromeTests.7z
-          7z x -y .\ChromeTests.7z
-      - name: Run Tests
-        id: runTests
-        timeout-minutes: 30
-        continue-on-error: true
-        run: |
-          cd ${{ env.TEST_LOCATION }}
-          .\nunit3-console.exe ChromeTests.dll --encoding=utf-8 --domain=None --inprocess --labels=All --testparam non-interactive=true `
-            --result=${{ env.ORIGINAL_RESULT_FILE }} `
-            --where "cat != DontRunForReleaseBuild and cat == Batch${{ matrix.batch }}"
-      - name: Rerun Failed Test
-        if: steps.runTests.outcome == 'failure'
-        id: rerunTests
-        timeout-minutes: 30
-        run: |
-          cd ${{ env.TEST_LOCATION }}
-          $OriginalFailTestResult = "OriginalFailTestResult.txt"
-          Select-Xml -XPath '//test-case' `
-            -Path '${{ env.ORIGINAL_RESULT_FILE }}' `
-            | Select-Object -Expand Node `
-            | where {$_.result -eq "Failed"} `
-            | Select-Object -Expand 'fullname' `
-            | Out-File -FilePath $OriginalFailTestResult
-          .\nunit3-console.exe ChromeTests.dll --encoding=utf-8 --domain=None --inprocess --labels=All --testparam non-interactive=true `
-            --result=${{ env.RERUN_RESULT_FILE }} `
-            --testlist $OriginalFailTestResult
-      - name: Upload Artifacts
-        if: always() && steps.rerunTests.outcome == 'failure'
-        run: |
-          azcopy cp "${{ env.TEST_LOCATION }}/Artifacts/*" "${{ env.ENDPOINT_OUTPUT_SCREENSHOTS }}/${{ env.COMMIT_SHA }}?${{ env.TOKEN_CONTAINER_SCREENSHOTS }}" --recursive --put-md5
-      - name: Report Testruns to Database
-        if: always()
-        run: |
-          Import-Module -Name SimplySql
-          cd ${{ env.TEST_LOCATION }}
-          Open-MySqlConnection -ConnectionString "${{ env.CONNECTION_STRING_AUTOTEST_DB }}"
-          if ( Test-Path ${{ env.ORIGINAL_RESULT_FILE }} -PathType leaf )
-          {
-            Write-Host "Updating Test database for Tests"
-            Write-Host "================================"
-            $TestResults = Select-Xml -XPath '//test-case' `
-              -Path '${{ env.ORIGINAL_RESULT_FILE }}' `
-              | Select-Object -Expand Node
-            foreach ($Test in $TestResults) {
-              try {
-                $TestName = echo $Test | Select-Object -Expand 'fullname'
-                $TestDuration = echo $Test | Select-Object -Expand 'duration'
-                $TestStartTime = echo $Test | Select-Object -Expand 'start-time'
-                $TestResult = echo $Test | Select-Object -Expand 'result'
-                $TestLogDir = 'Github Action'
-                $Revision = '${{ env.COMMIT_SHA }}'
-                $Branch = '${{ env.BRANCH }}'
-                $TestId = $(Invoke-SqlQuery -query "select TestID from Test where TestType = 'ChromeTest' and TestName = @TestName" -Parameters @{TestName = $TestName}).TestID | Select-Object -first 1
-                if ( $TestId -eq $null) {
-                  Invoke-SqlUpdate -query "insert into Test(TestType, TestName) values('ChromeTest', @TestName)" -Parameters @{TestName = $TestName}
-                  $TestId = $(Invoke-SqlQuery -query "select TestID from Test where TestType = 'ChromeTest' and TestName = @TestName" -Parameters @{TestName = $TestName}).TestID | Select-Object -first 1
-                }
-                Write-Host $TestId $TestName $TestResult
-                Invoke-SqlUpdate -query `
-                  "insert into TestRun(TestID, Revision, WhenRun, Branch, Duration, Result, LogPath) values(@TestId ,@Revision , @TestStartTime, @Branch, @TestDuration, @Result, @LogPath)" `
-                  -Parameters @{TestId=$TestId; StartTime=$TestStartTime; Revision=$Revision; TestStartTime=$TestStartTime; Branch=$Branch; TestDuration=$TestDuration; Result=$Result; LogPath=$TestLogDir}
-              } catch {
-                Write-Warning "Error recording result of following test:  $($TestName)"
-              }
-            }
+      - name: Debug Opensans
+        run: | 
+          ls C:/ProgramData/chocolatey/lib/OpenSans/tools
+          ls C:/ProgramData/chocolatey/lib/OpenSans
+      # - uses: actions/cache@v2
+      #   name: Get Fontawesome From Cache
+      #   id: cache-fontawesome
+      #   with:
+      #     path: ./font-awesome-${{ env.FONT_AWESOME_VERSION }}
+      #     key: ${{ runner.os }}-font-awesome-${{ env.FONT_AWESOME_VERSION }}
+      # - uses: actions/cache@v2
+      #   name: Get SimplySql From Cache
+      #   id: cache-simplysql
+      #   with:
+      #     path: C:\Users\runneradmin\Documents\PowerShell\Modules\SimplySql
+      #     key: ${{ runner.os }}-simplysql-${{ env.SIMPLY_SQL_VERSION }}
+      # - name: Fontawesome set HKCU
+      #   run: |
+      #     $FontPath = Join-Path $pwd font-awesome-${{ env.FONT_AWESOME_VERSION }}\fonts\fontawesome-webfont.ttf
+      #     Set-ItemProperty -path "HKCU:\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Fonts" -name "FontAwesome" -value "$FontPath"
+      # - name: Download and Extract Release
+      #   run: |
+      #     $uri = "${{ env.ENDPOINT_CHROMETEST }}/${{ env.BUILD_NUMBER }}/ChromeTests.7z?${{ secrets.ACCESS_TOKEN_CONTAINER_BUILDS }}"
+      #     Invoke-WebRequest -Uri $uri -OutFile ChromeTests.7z
+      #     7z x -y .\ChromeTests.7z
+      # - name: Run Tests
+      #   id: runTests
+      #   timeout-minutes: 30
+      #   continue-on-error: true
+      #   run: |
+      #     cd ${{ env.TEST_LOCATION }}
+      #     .\nunit3-console.exe ChromeTests.dll --encoding=utf-8 --domain=None --inprocess --labels=All --testparam non-interactive=true `
+      #       --result=${{ env.ORIGINAL_RESULT_FILE }} `
+      #       --where "cat != DontRunForReleaseBuild and cat == Batch${{ matrix.batch }}"
+      # - name: Rerun Failed Test
+      #   if: steps.runTests.outcome == 'failure'
+      #   id: rerunTests
+      #   timeout-minutes: 30
+      #   run: |
+      #     cd ${{ env.TEST_LOCATION }}
+      #     $OriginalFailTestResult = "OriginalFailTestResult.txt"
+      #     Select-Xml -XPath '//test-case' `
+      #       -Path '${{ env.ORIGINAL_RESULT_FILE }}' `
+      #       | Select-Object -Expand Node `
+      #       | where {$_.result -eq "Failed"} `
+      #       | Select-Object -Expand 'fullname' `
+      #       | Out-File -FilePath $OriginalFailTestResult
+      #     .\nunit3-console.exe ChromeTests.dll --encoding=utf-8 --domain=None --inprocess --labels=All --testparam non-interactive=true `
+      #       --result=${{ env.RERUN_RESULT_FILE }} `
+      #       --testlist $OriginalFailTestResult
+      # - name: Upload Artifacts
+      #   if: always() && steps.rerunTests.outcome == 'failure'
+      #   run: |
+      #     azcopy cp "${{ env.TEST_LOCATION }}/Artifacts/*" "${{ env.ENDPOINT_OUTPUT_SCREENSHOTS }}/${{ env.COMMIT_SHA }}?${{ env.TOKEN_CONTAINER_SCREENSHOTS }}" --recursive --put-md5
+      # - name: Report Testruns to Database
+      #   if: always()
+      #   run: |
+      #     Import-Module -Name SimplySql
+      #     cd ${{ env.TEST_LOCATION }}
+      #     Open-MySqlConnection -ConnectionString "${{ env.CONNECTION_STRING_AUTOTEST_DB }}"
+      #     if ( Test-Path ${{ env.ORIGINAL_RESULT_FILE }} -PathType leaf )
+      #     {
+      #       Write-Host "Updating Test database for Tests"
+      #       Write-Host "================================"
+      #       $TestResults = Select-Xml -XPath '//test-case' `
+      #         -Path '${{ env.ORIGINAL_RESULT_FILE }}' `
+      #         | Select-Object -Expand Node
+      #       foreach ($Test in $TestResults) {
+      #         try {
+      #           $TestName = echo $Test | Select-Object -Expand 'fullname'
+      #           $TestDuration = echo $Test | Select-Object -Expand 'duration'
+      #           $TestStartTime = echo $Test | Select-Object -Expand 'start-time'
+      #           $TestResult = echo $Test | Select-Object -Expand 'result'
+      #           $TestLogDir = 'Github Action'
+      #           $Revision = '${{ env.COMMIT_SHA }}'
+      #           $Branch = '${{ env.BRANCH }}'
+      #           $TestId = $(Invoke-SqlQuery -query "select TestID from Test where TestType = 'ChromeTest' and TestName = @TestName" -Parameters @{TestName = $TestName}).TestID | Select-Object -first 1
+      #           if ( $TestId -eq $null) {
+      #             Invoke-SqlUpdate -query "insert into Test(TestType, TestName) values('ChromeTest', @TestName)" -Parameters @{TestName = $TestName}
+      #             $TestId = $(Invoke-SqlQuery -query "select TestID from Test where TestType = 'ChromeTest' and TestName = @TestName" -Parameters @{TestName = $TestName}).TestID | Select-Object -first 1
+      #           }
+      #           Write-Host $TestId $TestName $TestResult
+      #           Invoke-SqlUpdate -query `
+      #             "insert into TestRun(TestID, Revision, WhenRun, Branch, Duration, Result, LogPath) values(@TestId ,@Revision , @TestStartTime, @Branch, @TestDuration, @Result, @LogPath)" `
+      #             -Parameters @{TestId=$TestId; StartTime=$TestStartTime; Revision=$Revision; TestStartTime=$TestStartTime; Branch=$Branch; TestDuration=$TestDuration; Result=$Result; LogPath=$TestLogDir}
+      #         } catch {
+      #           Write-Warning "Error recording result of following test:  $($TestName)"
+      #         }
+      #       }
 
-          }
-          if ( Test-Path ${{ env.RERUN_RESULT_FILE }} -PathType leaf )
-          {
-            Write-Host ""
-            Write-Host "Updating Test database for Unreliable Tests"
-            Write-Host "================================"
-            $TestResults = Select-Xml -XPath '//test-case' `
-              -Path '${{ env.RERUN_RESULT_FILE }}' `
-              | Select-Object -Expand Node `
-              | where {$_.result -eq "Passed"}
-              | Select-Object -Expand 'fullname'
-            foreach ($Test in $TestResults) {
-              try {
-                Write-Host $Test
-                $TestId = $(Invoke-SqlQuery -query "select TestID from Test where TestType = 'ChromeTest' and TestName = @TestName" -Parameters @{TestName = $Test}).TestID | Select-Object -first 1
-                Invoke-SqlUpdate -query "INSERT INTO UnreliableTest(TestID) VALUES (@TestId)"  -Parameters @{TestId=$TestId}
-              } catch {
-                Write-Warning "Error recording result of following test:  $($Test)"
-              }
-            }
-          }
+      #     }
+      #     if ( Test-Path ${{ env.RERUN_RESULT_FILE }} -PathType leaf )
+      #     {
+      #       Write-Host ""
+      #       Write-Host "Updating Test database for Unreliable Tests"
+      #       Write-Host "================================"
+      #       $TestResults = Select-Xml -XPath '//test-case' `
+      #         -Path '${{ env.RERUN_RESULT_FILE }}' `
+      #         | Select-Object -Expand Node `
+      #         | where {$_.result -eq "Passed"}
+      #         | Select-Object -Expand 'fullname'
+      #       foreach ($Test in $TestResults) {
+      #         try {
+      #           Write-Host $Test
+      #           $TestId = $(Invoke-SqlQuery -query "select TestID from Test where TestType = 'ChromeTest' and TestName = @TestName" -Parameters @{TestName = $Test}).TestID | Select-Object -first 1
+      #           Invoke-SqlUpdate -query "INSERT INTO UnreliableTest(TestID) VALUES (@TestId)"  -Parameters @{TestId=$TestId}
+      #         } catch {
+      #           Write-Warning "Error recording result of following test:  $($Test)"
+      #         }
+      #       }
+      #     }

--- a/.github/workflows/chrometest_run-batches.yml
+++ b/.github/workflows/chrometest_run-batches.yml
@@ -44,17 +44,7 @@ jobs:
       ARRAY_SIZE: ${{ inputs.batchNumber }}
     steps:
       - id: matrixArray
-        run: |
-          end=$[ ${{ env.ARRAY_SIZE }} - 1 ]
-          ary="["
-          for ((i=0; i<=$end; i++))
-          do 
-            if [ $i -ne $end ]
-              then ary+="$i, "
-            else ary+="$i]" 
-            fi
-          done
-          echo "::set-output name=arr::$ary"
+        run: echo "::set-output name=arr::[$(seq -s ", " 0 $[ ${{ env.ARRAY_SIZE }} - 1 ])]"
 
   install_dependencies_to_cache:
     name: Install Dependencies to Caches
@@ -64,6 +54,8 @@ jobs:
       OPENSANS_VERSION: "2.010"
       SIMPLY_SQL_VERSION: "1.8.0"
     steps:
+    - name: check fonts before cache
+      run: Get-ChildItem -Path C:/Windows/Fonts
     - uses: actions/cache@v2
       name: Check Opensans Cache
       id: cache-opensans
@@ -97,6 +89,8 @@ jobs:
       if: steps.cache-simplysql.outputs.cache-hit != 'true'
       run: |
         Install-Module -Name SimplySql -RequiredVersion ${{ env.SIMPLY_SQL_VERSION }} -Confirm:$False -Force
+    - name: check fonts after cache
+      run: Get-ChildItem -Path C:/Windows/Fonts
 
   run_batch:
     name: Run Chrome Test Batches

--- a/.github/workflows/chrometest_run-batches.yml
+++ b/.github/workflows/chrometest_run-batches.yml
@@ -54,6 +54,7 @@ jobs:
             else ary+="$i]" 
             fi
           done
+          echo $ary
           echo "::set-output name=arr::$ary"
 
   install_dependencies_to_cache:

--- a/.github/workflows/chrometest_run-batches.yml
+++ b/.github/workflows/chrometest_run-batches.yml
@@ -2,6 +2,10 @@ name: Reusable Workflow to Run Chrome Test Batches
 on:
   workflow_call:
     inputs:
+      matrixArray:
+        description: Array to use as batch matrix
+        required: true
+        type: string
       batchNumber:
         description: number of batches to run
         required: true
@@ -35,17 +39,6 @@ on:
         required: true
 
 jobs:
-  generate_batch_matrix:
-    name: Generate Batch Matrix
-    runs-on: ubuntu-latest
-    outputs:
-      MATRIX_ARRAY: ${{ steps.matrixArray.outputs.arr }}
-    env: 
-      ARRAY_SIZE: ${{ inputs.batchNumber }}
-    steps:
-      - id: matrixArray
-        run: echo "::set-output name=arr::[$(seq -s ", " 0 $[ ${{ env.ARRAY_SIZE }} - 1 ])]"
-
   install_dependencies_to_cache:
     name: Install Dependencies to Caches
     runs-on: windows-2019
@@ -54,46 +47,32 @@ jobs:
       OPENSANS_VERSION: "2.010"
       SIMPLY_SQL_VERSION: "1.8.0"
     steps:
-    - name: check fonts before cache
-      run: Get-ChildItem -Path C:/Windows/Fonts
     - uses: actions/cache@v2
-      name: Check Opensans Cache
-      id: cache-opensans
+      name: Check Cache
+      id: cache-dependencies
       with:
-        path: C:\ProgramData\chocolatey\lib\OpenSans\tools
-        key: -opensans-${{ env.OPENSANS_VERSION }}
-    - name: Install Opensans
-      if: steps.cache-opensans.outputs.cache-hit != 'true'
-      run: choco install -y opensans --version ${{ env.OPENSANS_VERSION }}
-    - uses: actions/cache@v2
-      name: Check Fontawesome Cache
-      id: cache-fontawesome
-      with:
-        path: .\font-awesome-${{ env.FONT_AWESOME_VERSION }}\fonts\fontawesome-webfont.ttf
-        key: font-awesome-${{ env.FONT_AWESOME_VERSION }}
-    - name: Install Fontawesome
-      if: steps.cache-fontawesome.outputs.cache-hit != 'true'
+        path: |
+          C:\ProgramData\chocolatey\lib\OpenSans\tools\*.ttf
+          .\font-awesome-${{ env.FONT_AWESOME_VERSION }}\fonts\fontawesome-webfont.ttf
+          C:\Users\runneradmin\Documents\PowerShell\Modules\SimplySql\${{ env.SIMPLY_SQL_VERSION }}
+        key: opensans-${{ env.OPENSANS_VERSION }}-fontawesome-${{ env.FONT_AWESOME_VERSION }}-simplysql-${{ env.SIMPLY_SQL_VERSION }}
+    - name: Install Dependencies
+      if: steps.cache-dependencies.outputs.cache-hit != 'true'
       run: |
+        choco install -y opensans --version ${{ env.OPENSANS_VERSION }}
         Add-Type -AssemblyName System.IO.Compression.FileSystem
         $FontAwesomeUri = "https://github.com/FortAwesome/Font-Awesome/archive/v${{ env.FONT_AWESOME_VERSION }}.zip"
         $FontAwesome = "font-awesome-${{ env.FONT_AWESOME_VERSION }}.zip"
         Invoke-WebRequest $FontAwesomeUri -OutFile $FontAwesome 
         [System.IO.Compression.ZipFile]::ExtractToDirectory($FontAwesome, "./")
-    - uses: actions/cache@v2
-      name: Check Simplysql Cache
-      id: cache-simplysql
-      with:
-        path: C:\Users\runneradmin\Documents\PowerShell\Modules\SimplySql\${{ env.SIMPLY_SQL_VERSION }}
-        key: simplysql-${{ env.SIMPLY_SQL_VERSION }}
-    - name: Install SimplySql
-      if: steps.cache-simplysql.outputs.cache-hit != 'true'
-      run: Install-Module -Name SimplySql -RequiredVersion ${{ env.SIMPLY_SQL_VERSION }} -Confirm:$False -Force
+        Install-Module -Name SimplySql -RequiredVersion ${{ env.SIMPLY_SQL_VERSION }} -Confirm:$False -Force
 
   run_batch:
     name: Run Chrome Test Batches
     runs-on: windows-2019
-    needs: [install_dependencies_to_cache, generate_batch_matrix]
+    needs: [install_dependencies_to_cache]
     env:
+      MATRIX_ARRAY: ${{ inputs.matrixArray }}
       BRANCH: ${{ inputs.branch }}
       BUILD_NUMBER: ${{ inputs.buildNumber }}
       COMMIT_SHA: ${{ inputs.commitSha }}
@@ -111,30 +90,20 @@ jobs:
     strategy:
       fail-fast: false
       matrix: 
-        batch: ${{ fromJSON(needs.generate_batch_matrix.outputs.MATRIX_ARRAY) }}
+        batch: ${{ fromJSON(env.MATRIX_ARRAY) }}
     steps:
       - uses: actions/cache@v2
-        name: Get Opensans from cache
-        id: cache-opensans
+        name: Get Dependencies From Cache
+        id: cache
         with:
-          path: C:\ProgramData\chocolatey\lib\OpenSans\tools
-          key: -opensans-${{ env.OPENSANS_VERSION }}
-      - name: Set OpenSans HKCU
-        run: Get-ChildItem -Path C:\ProgramData\chocolatey\lib\OpenSans\tools\*.ttf | %{ Set-ItemProperty -Path "HKCU:\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Fonts" -Name "$($_.Basename) (TrueType)" -Type STRING -Value $_.fullname }
-      - uses: actions/cache@v2
-        name: Get Fontawesome From Cache
-        id: cache-fontawesome
-        with:
-          path: .\font-awesome-${{ env.FONT_AWESOME_VERSION }}\fonts\fontawesome-webfont.ttf
-          key: font-awesome-${{ env.FONT_AWESOME_VERSION }}
-      - uses: actions/cache@v2
-        name: Get SimplySql From Cache
-        id: cache-simplysql
-        with:
-          path: C:\Users\runneradmin\Documents\PowerShell\Modules\SimplySql\${{ env.SIMPLY_SQL_VERSION }}
-          key: simplysql-${{ env.SIMPLY_SQL_VERSION }}
-      - name: Set Fontawesome HKCU
+          path: |
+            C:\ProgramData\chocolatey\lib\OpenSans\tools\*.ttf
+            .\font-awesome-${{ env.FONT_AWESOME_VERSION }}\fonts\fontawesome-webfont.ttf
+            C:\Users\runneradmin\Documents\PowerShell\Modules\SimplySql\${{ env.SIMPLY_SQL_VERSION }}
+          key: opensans-${{ env.OPENSANS_VERSION }}-fontawesome-${{ env.FONT_AWESOME_VERSION }}-simplysql-${{ env.SIMPLY_SQL_VERSION }}}
+      - name: Set OpenSans and Fontawesome HKCU
         run: |
+          Get-ChildItem -Path C:\ProgramData\chocolatey\lib\OpenSans\tools\*.ttf | %{ Set-ItemProperty -Path "HKCU:\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Fonts" -Name "$($_.Basename) (TrueType)" -Type STRING -Value $_.fullname }
           $FontPath = Join-Path $pwd font-awesome-${{ env.FONT_AWESOME_VERSION }}\fonts\fontawesome-webfont.ttf
           Set-ItemProperty -Path "HKCU:\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Fonts" -Name "FontAwesome" -Value "$FontPath"
       - name: Download and Extract Release

--- a/.github/workflows/chrometest_run-batches.yml
+++ b/.github/workflows/chrometest_run-batches.yml
@@ -45,7 +45,7 @@ jobs:
     steps:
       - id: matrixAraray
         run: |
-          end=$[ ${{ env.MATRIX_SIZE }} - 1 ]
+          end=$[ ${{ env.ARRAY_SIZE }} - 1 ]
           ary="["
           for ((i=0; i<=$end; i++))
           do 

--- a/.github/workflows/chrometest_run-batches.yml
+++ b/.github/workflows/chrometest_run-batches.yml
@@ -99,7 +99,8 @@ jobs:
           key: opensans-${{ env.OPENSANS_VERSION }}-fontawesome-${{ env.FONT_AWESOME_VERSION }}-simplysql-${{ env.SIMPLY_SQL_VERSION }}
       - name: Set OpenSans and Fontawesome HKCU
         run: |
-          Get-ChildItem -Path C:\ProgramData\chocolatey\lib\OpenSans\tools\*.ttf | %{ Set-ItemProperty -Path "HKCU:\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Fonts" -Name "$($_.Basename) (TrueType)" -Type STRING -Value $_.fullname }
+          Get-ChildItem -Path C:\ProgramData\chocolatey\lib\OpenSans\tools\*.ttf `
+            | %{ Set-ItemProperty -Path "HKCU:\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Fonts" -Name "$($_.Basename) (TrueType)" -Type STRING -Value $_.fullname }
           $FontPath = Join-Path $pwd font-awesome-${{ env.FONT_AWESOME_VERSION }}\fonts\fontawesome-webfont.ttf
           Set-ItemProperty -Path "HKCU:\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Fonts" -Name "FontAwesome" -Value "$FontPath"
       - name: Download and Extract Release

--- a/.github/workflows/chrometest_run-batches.yml
+++ b/.github/workflows/chrometest_run-batches.yml
@@ -140,7 +140,6 @@ jobs:
       - name: Report Testruns to Database
         if: always()
         run: |
-          ls C:\Users\runneradmin\Documents\PowerShell\Modules\
           Import-Module -Name SimplySql
           cd ${{ env.TEST_LOCATION }}
           Open-MySqlConnection -ConnectionString "${{ env.CONNECTION_STRING_AUTOTEST_DB }}"

--- a/.github/workflows/chrometest_run-batches.yml
+++ b/.github/workflows/chrometest_run-batches.yml
@@ -44,7 +44,17 @@ jobs:
       ARRAY_SIZE: ${{ inputs.batchNumber }}
     steps:
       - id: matrixAraray
-        run: echo "::set-output name=arr::[$(seq -s ", " 0 $[ ${{ env.ARRAY_SIZE }} - 1 ])]"
+        run: |
+          end=$[ ${{ env.MATRIX_SIZE }} - 1 ]
+          ary="["
+          for ((i=0; i<=$end; i++))
+          do 
+            if [ $i -ne $end ]
+              then ary+="$i, "
+            else ary+="$i]" 
+            fi
+          done
+          echo "::set-output name=arr::$ary"
 
   install_dependencies_to_cache:
     name: Install Dependencies to Caches

--- a/.github/workflows/chrometest_run-batches.yml
+++ b/.github/workflows/chrometest_run-batches.yml
@@ -128,7 +128,7 @@ jobs:
           key: -opensans-${{ env.OPENSANS_VERSION }}
       - name: install open sans
         run: |
-          Import-Module -Name chcolatey-font-helpers
+          Import-Module -Name chocolatey-font-helpers
           Install-ChocolateyFont "C:/ProgramData/chocolatey/lib/OpenSans/tools/OpenSans-Bold.ttf"
           Install-ChocolateyFont "C:/ProgramData/chocolatey/lib/OpenSans/tools/OpenSans-BoldItalic.ttf"
           Install-ChocolateyFont "C:/ProgramData/chocolatey/lib/OpenSans/tools/OpenSans-CondBold.ttf"

--- a/.github/workflows/chrometest_run-batches.yml
+++ b/.github/workflows/chrometest_run-batches.yml
@@ -43,7 +43,7 @@ jobs:
     env: 
       ARRAY_SIZE: ${{ inputs.batchNumber }}
     steps:
-      - id: matrixAraray
+      - id: matrixArray
         run: |
           end=$[ ${{ env.ARRAY_SIZE }} - 1 ]
           ary="["

--- a/.github/workflows/chrometest_run-batches.yml
+++ b/.github/workflows/chrometest_run-batches.yml
@@ -134,110 +134,110 @@ jobs:
           ls C:/ProgramData/chocolatey/lib/OpenSans/tools
           ls C:/ProgramData/chocolatey/lib/OpenSans
           echo ${{ matrix.batch }}
-      # - uses: actions/cache@v2
-      #   name: Get Fontawesome From Cache
-      #   id: cache-fontawesome
-      #   with:
-      #     path: ./font-awesome-${{ env.FONT_AWESOME_VERSION }}
-      #     key: font-awesome-${{ env.FONT_AWESOME_VERSION }}
-      # - uses: actions/cache@v2
-      #   name: Get SimplySql From Cache
-      #   id: cache-simplysql
-      #   with:
-      #     path: C:\Users\runneradmin\Documents\PowerShell\Modules\SimplySql
-      #     key: simplysql-${{ env.SIMPLY_SQL_VERSION }}
-      # - name: Fontawesome set HKCU
-      #   run: |
-      #     $FontPath = Join-Path $pwd font-awesome-${{ env.FONT_AWESOME_VERSION }}\fonts\fontawesome-webfont.ttf
-      #     Set-ItemProperty -path "HKCU:\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Fonts" -name "FontAwesome" -value "$FontPath"
-      # - name: Download and Extract Release
-      #   run: |
-      #     $uri = "${{ env.ENDPOINT_CHROMETEST }}/${{ env.BUILD_NUMBER }}/ChromeTests.7z?${{ secrets.ACCESS_TOKEN_CONTAINER_BUILDS }}"
-      #     Invoke-WebRequest -Uri $uri -OutFile ChromeTests.7z
-      #     7z x -y .\ChromeTests.7z
-      # - name: Run Tests
-      #   id: runTests
-      #   timeout-minutes: 30
-      #   continue-on-error: true
-      #   run: |
-      #     cd ${{ env.TEST_LOCATION }}
-      #     .\nunit3-console.exe ChromeTests.dll --encoding=utf-8 --domain=None --inprocess --labels=All --testparam non-interactive=true `
-      #       --result=${{ env.ORIGINAL_RESULT_FILE }} `
-      #       --where "cat != DontRunForReleaseBuild and cat == Batch${{ matrix.batch }}"
-      # - name: Rerun Failed Test
-      #   if: steps.runTests.outcome == 'failure'
-      #   id: rerunTests
-      #   timeout-minutes: 30
-      #   run: |
-      #     cd ${{ env.TEST_LOCATION }}
-      #     $OriginalFailTestResult = "OriginalFailTestResult.txt"
-      #     Select-Xml -XPath '//test-case' `
-      #       -Path '${{ env.ORIGINAL_RESULT_FILE }}' `
-      #       | Select-Object -Expand Node `
-      #       | where {$_.result -eq "Failed"} `
-      #       | Select-Object -Expand 'fullname' `
-      #       | Out-File -FilePath $OriginalFailTestResult
-      #     .\nunit3-console.exe ChromeTests.dll --encoding=utf-8 --domain=None --inprocess --labels=All --testparam non-interactive=true `
-      #       --result=${{ env.RERUN_RESULT_FILE }} `
-      #       --testlist $OriginalFailTestResult
-      # - name: Upload Artifacts
-      #   if: always() && steps.rerunTests.outcome == 'failure'
-      #   run: |
-      #     azcopy cp "${{ env.TEST_LOCATION }}/Artifacts/*" "${{ env.ENDPOINT_OUTPUT_SCREENSHOTS }}/${{ env.COMMIT_SHA }}?${{ env.TOKEN_CONTAINER_SCREENSHOTS }}" --recursive --put-md5
-      # - name: Report Testruns to Database
-      #   if: always()
-      #   run: |
-      #     Import-Module -Name SimplySql
-      #     cd ${{ env.TEST_LOCATION }}
-      #     Open-MySqlConnection -ConnectionString "${{ env.CONNECTION_STRING_AUTOTEST_DB }}"
-      #     if ( Test-Path ${{ env.ORIGINAL_RESULT_FILE }} -PathType leaf )
-      #     {
-      #       Write-Host "Updating Test database for Tests"
-      #       Write-Host "================================"
-      #       $TestResults = Select-Xml -XPath '//test-case' `
-      #         -Path '${{ env.ORIGINAL_RESULT_FILE }}' `
-      #         | Select-Object -Expand Node
-      #       foreach ($Test in $TestResults) {
-      #         try {
-      #           $TestName = echo $Test | Select-Object -Expand 'fullname'
-      #           $TestDuration = echo $Test | Select-Object -Expand 'duration'
-      #           $TestStartTime = echo $Test | Select-Object -Expand 'start-time'
-      #           $TestResult = echo $Test | Select-Object -Expand 'result'
-      #           $TestLogDir = 'Github Action'
-      #           $Revision = '${{ env.COMMIT_SHA }}'
-      #           $Branch = '${{ env.BRANCH }}'
-      #           $TestId = $(Invoke-SqlQuery -query "select TestID from Test where TestType = 'ChromeTest' and TestName = @TestName" -Parameters @{TestName = $TestName}).TestID | Select-Object -first 1
-      #           if ( $TestId -eq $null) {
-      #             Invoke-SqlUpdate -query "insert into Test(TestType, TestName) values('ChromeTest', @TestName)" -Parameters @{TestName = $TestName}
-      #             $TestId = $(Invoke-SqlQuery -query "select TestID from Test where TestType = 'ChromeTest' and TestName = @TestName" -Parameters @{TestName = $TestName}).TestID | Select-Object -first 1
-      #           }
-      #           Write-Host $TestId $TestName $TestResult
-      #           Invoke-SqlUpdate -query `
-      #             "insert into TestRun(TestID, Revision, WhenRun, Branch, Duration, Result, LogPath) values(@TestId ,@Revision , @TestStartTime, @Branch, @TestDuration, @Result, @LogPath)" `
-      #             -Parameters @{TestId=$TestId; StartTime=$TestStartTime; Revision=$Revision; TestStartTime=$TestStartTime; Branch=$Branch; TestDuration=$TestDuration; Result=$Result; LogPath=$TestLogDir}
-      #         } catch {
-      #           Write-Warning "Error recording result of following test:  $($TestName)"
-      #         }
-      #       }
+      - uses: actions/cache@v2
+        name: Get Fontawesome From Cache
+        id: cache-fontawesome
+        with:
+          path: ./font-awesome-${{ env.FONT_AWESOME_VERSION }}
+          key: font-awesome-${{ env.FONT_AWESOME_VERSION }}
+      - uses: actions/cache@v2
+        name: Get SimplySql From Cache
+        id: cache-simplysql
+        with:
+          path: C:\Users\runneradmin\Documents\PowerShell\Modules\SimplySql
+          key: simplysql-${{ env.SIMPLY_SQL_VERSION }}
+      - name: Fontawesome set HKCU
+        run: |
+          $FontPath = Join-Path $pwd font-awesome-${{ env.FONT_AWESOME_VERSION }}\fonts\fontawesome-webfont.ttf
+          Set-ItemProperty -path "HKCU:\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Fonts" -name "FontAwesome" -value "$FontPath"
+      - name: Download and Extract Release
+        run: |
+          $uri = "${{ env.ENDPOINT_CHROMETEST }}/${{ env.BUILD_NUMBER }}/ChromeTests.7z?${{ secrets.ACCESS_TOKEN_CONTAINER_BUILDS }}"
+          Invoke-WebRequest -Uri $uri -OutFile ChromeTests.7z
+          7z x -y .\ChromeTests.7z
+      - name: Run Tests
+        id: runTests
+        timeout-minutes: 30
+        continue-on-error: true
+        run: |
+          cd ${{ env.TEST_LOCATION }}
+          .\nunit3-console.exe ChromeTests.dll --encoding=utf-8 --domain=None --inprocess --labels=All --testparam non-interactive=true `
+            --result=${{ env.ORIGINAL_RESULT_FILE }} `
+            --where "cat != DontRunForReleaseBuild and cat == Batch${{ matrix.batch }}"
+      - name: Rerun Failed Test
+        if: steps.runTests.outcome == 'failure'
+        id: rerunTests
+        timeout-minutes: 30
+        run: |
+          cd ${{ env.TEST_LOCATION }}
+          $OriginalFailTestResult = "OriginalFailTestResult.txt"
+          Select-Xml -XPath '//test-case' `
+            -Path '${{ env.ORIGINAL_RESULT_FILE }}' `
+            | Select-Object -Expand Node `
+            | where {$_.result -eq "Failed"} `
+            | Select-Object -Expand 'fullname' `
+            | Out-File -FilePath $OriginalFailTestResult
+          .\nunit3-console.exe ChromeTests.dll --encoding=utf-8 --domain=None --inprocess --labels=All --testparam non-interactive=true `
+            --result=${{ env.RERUN_RESULT_FILE }} `
+            --testlist $OriginalFailTestResult
+      - name: Upload Artifacts
+        if: always() && steps.rerunTests.outcome == 'failure'
+        run: |
+          azcopy cp "${{ env.TEST_LOCATION }}/Artifacts/*" "${{ env.ENDPOINT_OUTPUT_SCREENSHOTS }}/${{ env.COMMIT_SHA }}?${{ env.TOKEN_CONTAINER_SCREENSHOTS }}" --recursive --put-md5
+      - name: Report Testruns to Database
+        if: always()
+        run: |
+          Import-Module -Name SimplySql
+          cd ${{ env.TEST_LOCATION }}
+          Open-MySqlConnection -ConnectionString "${{ env.CONNECTION_STRING_AUTOTEST_DB }}"
+          if ( Test-Path ${{ env.ORIGINAL_RESULT_FILE }} -PathType leaf )
+          {
+            Write-Host "Updating Test database for Tests"
+            Write-Host "================================"
+            $TestResults = Select-Xml -XPath '//test-case' `
+              -Path '${{ env.ORIGINAL_RESULT_FILE }}' `
+              | Select-Object -Expand Node
+            foreach ($Test in $TestResults) {
+              try {
+                $TestName = echo $Test | Select-Object -Expand 'fullname'
+                $TestDuration = echo $Test | Select-Object -Expand 'duration'
+                $TestStartTime = echo $Test | Select-Object -Expand 'start-time'
+                $TestResult = echo $Test | Select-Object -Expand 'result'
+                $TestLogDir = 'Github Action'
+                $Revision = '${{ env.COMMIT_SHA }}'
+                $Branch = '${{ env.BRANCH }}'
+                $TestId = $(Invoke-SqlQuery -query "select TestID from Test where TestType = 'ChromeTest' and TestName = @TestName" -Parameters @{TestName = $TestName}).TestID | Select-Object -first 1
+                if ( $TestId -eq $null) {
+                  Invoke-SqlUpdate -query "insert into Test(TestType, TestName) values('ChromeTest', @TestName)" -Parameters @{TestName = $TestName}
+                  $TestId = $(Invoke-SqlQuery -query "select TestID from Test where TestType = 'ChromeTest' and TestName = @TestName" -Parameters @{TestName = $TestName}).TestID | Select-Object -first 1
+                }
+                Write-Host $TestId $TestName $TestResult
+                Invoke-SqlUpdate -query `
+                  "insert into TestRun(TestID, Revision, WhenRun, Branch, Duration, Result, LogPath) values(@TestId ,@Revision , @TestStartTime, @Branch, @TestDuration, @Result, @LogPath)" `
+                  -Parameters @{TestId=$TestId; StartTime=$TestStartTime; Revision=$Revision; TestStartTime=$TestStartTime; Branch=$Branch; TestDuration=$TestDuration; Result=$Result; LogPath=$TestLogDir}
+              } catch {
+                Write-Warning "Error recording result of following test:  $($TestName)"
+              }
+            }
 
-      #     }
-      #     if ( Test-Path ${{ env.RERUN_RESULT_FILE }} -PathType leaf )
-      #     {
-      #       Write-Host ""
-      #       Write-Host "Updating Test database for Unreliable Tests"
-      #       Write-Host "================================"
-      #       $TestResults = Select-Xml -XPath '//test-case' `
-      #         -Path '${{ env.RERUN_RESULT_FILE }}' `
-      #         | Select-Object -Expand Node `
-      #         | where {$_.result -eq "Passed"}
-      #         | Select-Object -Expand 'fullname'
-      #       foreach ($Test in $TestResults) {
-      #         try {
-      #           Write-Host $Test
-      #           $TestId = $(Invoke-SqlQuery -query "select TestID from Test where TestType = 'ChromeTest' and TestName = @TestName" -Parameters @{TestName = $Test}).TestID | Select-Object -first 1
-      #           Invoke-SqlUpdate -query "INSERT INTO UnreliableTest(TestID) VALUES (@TestId)"  -Parameters @{TestId=$TestId}
-      #         } catch {
-      #           Write-Warning "Error recording result of following test:  $($Test)"
-      #         }
-      #       }
-      #     }
+          }
+          if ( Test-Path ${{ env.RERUN_RESULT_FILE }} -PathType leaf )
+          {
+            Write-Host ""
+            Write-Host "Updating Test database for Unreliable Tests"
+            Write-Host "================================"
+            $TestResults = Select-Xml -XPath '//test-case' `
+              -Path '${{ env.RERUN_RESULT_FILE }}' `
+              | Select-Object -Expand Node `
+              | where {$_.result -eq "Passed"}
+              | Select-Object -Expand 'fullname'
+            foreach ($Test in $TestResults) {
+              try {
+                Write-Host $Test
+                $TestId = $(Invoke-SqlQuery -query "select TestID from Test where TestType = 'ChromeTest' and TestName = @TestName" -Parameters @{TestName = $Test}).TestID | Select-Object -first 1
+                Invoke-SqlUpdate -query "INSERT INTO UnreliableTest(TestID) VALUES (@TestId)"  -Parameters @{TestId=$TestId}
+              } catch {
+                Write-Warning "Error recording result of following test:  $($Test)"
+              }
+            }
+          }

--- a/.github/workflows/chrometest_run-batches.yml
+++ b/.github/workflows/chrometest_run-batches.yml
@@ -6,10 +6,6 @@ on:
         description: Array to use as batch matrix
         required: true
         type: string
-      batchNumber:
-        description: number of batches to run
-        required: true
-        type: string
       branch:
         description: The name of the git branch the build number is associate to.
         required: true

--- a/.github/workflows/chrometest_run-batches.yml
+++ b/.github/workflows/chrometest_run-batches.yml
@@ -60,7 +60,9 @@ jobs:
       name: Check Opensans Cache
       id: cache-opensans
       with:
-        path: C:/ProgramData/chocolatey/lib/OpenSans
+        path: | 
+          C:/ProgramData/chocolatey/lib/OpenSans/tools
+          C:/ProgramData/chocolatey/lib/chocolatey-font-helpers.extension/extensions/Install-ChocolateyFont.ps1
         key: opensans-${{ env.OPENSANS_VERSION }}
     - name: Install Opensans
       if: steps.cache-opensans.outputs.cache-hit != 'true'
@@ -116,18 +118,30 @@ jobs:
       matrix: 
         batch: ${{ fromJSON(needs.generate_batch_matrix.outputs.MATRIX_ARRAY) }}
     steps:
-    
       - uses: actions/cache@v2
         name: Get Opensans from cache
         id: cache-opensans
         with:
-          path: C:/ProgramData/chocolatey/lib/OpenSans
+          path: | 
+            C:/ProgramData/chocolatey/lib/OpenSans/tools
+            C:/ProgramData/chocolatey/lib/chocolatey-font-helpers.extension/extensions/Install-ChocolateyFont.ps1
           key: opensans-${{ env.OPENSANS_VERSION }}
-      - name: Debug Opensans
-        run: | 
-          ls C:/ProgramData/chocolatey/lib/OpenSans/tools
-          ls C:/ProgramData/chocolatey/lib/OpenSans
-          echo ${{ matrix.batch }}
+      - name: install open sans
+        run: |
+          Import-Module -Name chcolatey-font-helpers
+          Install-ChocolateyFont "C:/ProgramData/chocolatey/lib/OpenSans/tools/OpenSans-Bold.ttf"
+          Install-ChocolateyFont "C:/ProgramData/chocolatey/lib/OpenSans/tools/OpenSans-BoldItalic.ttf"
+          Install-ChocolateyFont "C:/ProgramData/chocolatey/lib/OpenSans/tools/OpenSans-CondBold.ttf"
+          Install-ChocolateyFont "C:/ProgramData/chocolatey/lib/OpenSans/tools/OpenSans-CondLight.ttf"
+          Install-ChocolateyFont "C:/ProgramData/chocolatey/lib/OpenSans/tools/OpenSans-CondLightItalic.ttf"
+          Install-ChocolateyFont "C:/ProgramData/chocolatey/lib/OpenSans/tools/OpenSans-ExtraBold.ttf"
+          Install-ChocolateyFont "C:/ProgramData/chocolatey/lib/OpenSans/tools/OpenSans-ExtraBoldItalic.ttf"
+          Install-ChocolateyFont "C:/ProgramData/chocolatey/lib/OpenSans/tools/OpenSans-Italic.ttf"
+          Install-ChocolateyFont "C:/ProgramData/chocolatey/lib/OpenSans/tools/OpenSans-Light.ttf"
+          Install-ChocolateyFont "C:/ProgramData/chocolatey/lib/OpenSans/tools/OpenSans-LightItalic.ttf"
+          Install-ChocolateyFont "C:/ProgramData/chocolatey/lib/OpenSans/tools/OpenSans-Regular.ttf"
+          Install-ChocolateyFont "C:/ProgramData/chocolatey/lib/OpenSans/tools/OpenSans-SemiBold.ttf"
+          Install-ChocolateyFont "C:/ProgramData/chocolatey/lib/OpenSans/tools/OpenSans-SemiBoldItalic.ttf"
       - uses: actions/cache@v2
         name: Get Fontawesome From Cache
         id: cache-fontawesome
@@ -138,7 +152,7 @@ jobs:
         name: Get SimplySql From Cache
         id: cache-simplysql
         with:
-          path: C:\Users\runneradmin\Documents\PowerShell\Modules\SimplySql
+          path: C:\Users\runneradmin\Documents\PowerShell\Modules\SimplySql\${{ env.SIMPLY_SQL_VERSION }}
           key: simplysql-${{ env.SIMPLY_SQL_VERSION }}
       - name: Fontawesome set HKCU
         run: |

--- a/.github/workflows/chrometest_run-batches.yml
+++ b/.github/workflows/chrometest_run-batches.yml
@@ -89,8 +89,8 @@ jobs:
       TEST_LOCATION: ChromeTests\bin\Release
     strategy:
       fail-fast: false
-      matrix: 
-        batch: ${{ fromJSON(env.MATRIX_ARRAY) }}
+      matrix:
+        batch: ${{ fromJSON( inputs.matrixArray ) }}
     steps:
       - uses: actions/cache@v2
         name: Get Dependencies From Cache


### PR DESCRIPTION
Added caching of dependencies: OpenSans, Fontawesome, SimplySql.
Previously installs took ~50s/batch - cache now takes ~5s/batch.
See test workflow run at: https://github.com/Displayr/q/actions/runs/1542623493