### PR TITLE
INF-84:  Unsuccessful downloads of ChromeInABox Artifact

### DIFF
--- a/.github/workflows/chrometest_run-batches.yml
+++ b/.github/workflows/chrometest_run-batches.yml
@@ -113,6 +113,14 @@ jobs:
           $FontPath = Join-Path $pwd font-awesome-${{ env.FONT_AWESOME_VERSION }}\fonts\fontawesome-webfont.ttf
           Set-ItemProperty -Path "HKCU:\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Fonts" -Name "FontAwesome" -Value "$FontPath"
       - name: Download and Extract Release
+        id: getChromeInABoxArtifact
+        continue-on-error: true
+        run: |
+          $uri = "${{ env.ENDPOINT_CHROMETEST }}/${{ env.BUILD_NUMBER }}/ChromeTests.7z?${{ secrets.ACCESS_TOKEN_CONTAINER_BUILDS }}"
+          Invoke-WebRequest -Uri $uri -OutFile ChromeTests.7z
+          7z x -y .\ChromeTests.7z
+      - name: Retry Download and Extract Release
+        if: steps.getChromeInABoxArtifact.outcome == 'failure'
         run: |
           $uri = "${{ env.ENDPOINT_CHROMETEST }}/${{ env.BUILD_NUMBER }}/ChromeTests.7z?${{ secrets.ACCESS_TOKEN_CONTAINER_BUILDS }}"
           Invoke-WebRequest -Uri $uri -OutFile ChromeTests.7z


### PR DESCRIPTION
We rerun the download and 7z extraction of the ChromeInABox Artifact to help with flaky downloads from azure blob storage